### PR TITLE
Default labels

### DIFF
--- a/lib/providers/labels.dart
+++ b/lib/providers/labels.dart
@@ -63,23 +63,54 @@ class Labels with ChangeNotifier {
     // If the default labels weren't in storage, add them here.
     if (this.findById(otherIncomeId) == null ||
         this.findById(otherExpenseId) == null) {
-      // By adding both of these labels, the user can edit labels without a problem. If these aren't added to the db,
-      // then the db will attempt to update a nonexistant label when edited.
-      this.addLabel(
+      const starterLabels = const <Label>[
+        // By adding both of these labels, the user can edit labels without a problem. If these aren't added to the db,
+        // then the db will attempt to update a nonexistant label when edited.
         Label(
           id: otherIncomeId,
           title: 'Other income',
           color: Colors.blueGrey,
           labelType: LabelType.INCOME,
         ),
-      );
-      this.addLabel(
         Label(
           id: otherExpenseId,
           title: 'Other expense',
-          color: Colors.orange,
+          color: Colors.grey,
           labelType: LabelType.EXPENSE,
         ),
+
+        // Some nice starter labels. They can be edited/deleted with no problem.
+        Label(
+          id: 'l3',
+          title: 'Job',
+          color: Colors.orange,
+          labelType: LabelType.INCOME,
+        ),
+        Label(
+          id: 'l4',
+          title: 'Groceries',
+          color: Colors.green,
+          labelType: LabelType.EXPENSE,
+        ),
+        Label(
+          id: 'l5',
+          title: 'Restaurants',
+          color: Colors.amber,
+          labelType: LabelType.EXPENSE,
+        ),
+        Label(
+          id: 'l6',
+          title: 'Luxury',
+          color: Colors.deepPurple,
+          labelType: LabelType.EXPENSE,
+        ),
+      ];
+
+      starterLabels.forEach(
+        (starterLabel) {
+          _items.add(starterLabel);
+          DBHelper.insertLabel(starterLabel);
+        },
       );
     }
     notifyListeners();

--- a/lib/screens/edit_label_screen.dart
+++ b/lib/screens/edit_label_screen.dart
@@ -93,15 +93,6 @@ class _EditLabelScreenState extends State<EditLabelScreen> {
     return Scaffold(
       appBar: AppBar(
         title: Text('${widget.editLabelId == null ? 'Add' : 'Edit'} Label'),
-        actions: <Widget>[
-          FlatButton(
-            onPressed: _saveForm,
-            child: Text(
-              'SAVE',
-              style: TextStyle(color: Theme.of(context).colorScheme.onPrimary),
-            ),
-          ),
-        ],
       ),
       body: Form(
         key: _formKey,
@@ -160,6 +151,14 @@ class _EditLabelScreenState extends State<EditLabelScreen> {
               onSaved: (newValue) {
                 _editableLabel.labelType = newValue;
               },
+            ),
+            const SizedBox(height: 5),
+            RaisedButton.icon(
+              color: Theme.of(context).primaryColor,
+              textColor: Theme.of(context).colorScheme.onPrimary,
+              onPressed: _saveForm,
+              icon: const Icon(Icons.save),
+              label: const Text('SAVE'),
             ),
           ],
         ),

--- a/lib/screens/edit_labels_screen.dart
+++ b/lib/screens/edit_labels_screen.dart
@@ -12,6 +12,25 @@ import '../widgets/app_drawer.dart';
 class EditLabelsScreen extends StatelessWidget {
   static const routeName = '/edit-labels';
 
+  Widget buildAddLabelButton(BuildContext context) {
+    return SliverList(
+      delegate: SliverChildListDelegate.fixed(
+        <Widget>[
+          Padding(
+            padding: const EdgeInsets.only(top: 8, left: 8, right: 8),
+            child: RaisedButton.icon(
+              color: Theme.of(context).primaryColor,
+              textColor: Theme.of(context).colorScheme.onPrimary,
+              onPressed: () => addLabel(context),
+              icon: const Icon(Icons.add),
+              label: const Text('ADD LABEL'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   List<Widget> _buildSliverHeaderList(
     BuildContext context,
     String headerText,
@@ -136,16 +155,11 @@ class EditLabelsScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Edit Labels'),
-        actions: <Widget>[
-          IconButton(
-            icon: const Icon(Icons.add),
-            onPressed: () => addLabel(context),
-          ),
-        ],
       ),
       drawer: AppDrawer(),
       body: CustomScrollView(
         slivers: <Widget>[
+          buildAddLabelButton(context),
           ..._buildSliverHeaderList(
             context,
             'Income Labels',


### PR DESCRIPTION
- Add some starter labels the user can start using. These can be edited/deleted safely (except for other income/expense, which can't be deleted but can be edited).
- Change Add Label and Save label buttons to raised buttons instead of being in the appbar.

![20-07-22-11-02-24](https://user-images.githubusercontent.com/7365763/88192965-1f4bf680-cc0b-11ea-96ac-cf1385d94d74.gif)
