### PR TITLE
Add Month Statistics for Pie Charts

### DIFF
--- a/lib/charts/chart_widgets/transaction_details_pie_chart.dart
+++ b/lib/charts/chart_widgets/transaction_details_pie_chart.dart
@@ -34,7 +34,7 @@ class TransactionDetailsPieChart extends StatelessWidget {
       children: <Widget>[
         Text(
           chartTitle,
-          style: Theme.of(context).textTheme.headline6.copyWith(fontSize: 24),
+          style: Theme.of(context).textTheme.headline6.copyWith(fontSize: 22),
         ),
         SizedBox(
           height: height,

--- a/lib/models/transaction.dart
+++ b/lib/models/transaction.dart
@@ -67,4 +67,12 @@ class Transaction {
     }
     return label;
   }
+
+  bool get isAfterBeginningOfMonth {
+    final today = DateTime.now();
+    // The day before the beginning of the month.
+    final beginningOfMonth = DateTime(today.year, today.month, 0);
+
+    return date.isAfter(beginningOfMonth);
+  }
 }

--- a/lib/providers/transactions.dart
+++ b/lib/providers/transactions.dart
@@ -39,14 +39,14 @@ class Transactions with ChangeNotifier {
   double get monthIncomeTotal {
     return _totalTransactionsAmountWithFilter(
       (transaction) =>
-          transaction.amount > 0 && _isAfterBeginningOfMonth(transaction.date),
+          transaction.amount > 0 && transaction.isAfterBeginningOfMonth,
     );
   }
 
   double get monthExpensesTotal {
     return _totalTransactionsAmountWithFilter(
       (transaction) =>
-          transaction.amount < 0 && _isAfterBeginningOfMonth(transaction.date),
+          transaction.amount < 0 && transaction.isAfterBeginningOfMonth,
     );
   }
 
@@ -60,14 +60,6 @@ class Transactions with ChangeNotifier {
       0,
       (previousValue, transaction) => previousValue + transaction.amount,
     );
-  }
-
-  bool _isAfterBeginningOfMonth(DateTime date) {
-    final today = DateTime.now();
-    // The day before the beginning of the month.
-    final beginningOfMonth = DateTime(today.year, today.month, 0);
-
-    return date.isAfter(beginningOfMonth);
   }
 
   Transaction findById(String id) {

--- a/lib/widgets/balance_cards_view.dart
+++ b/lib/widgets/balance_cards_view.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:scrolling_page_indicator/scrolling_page_indicator.dart';

--- a/lib/widgets/transaction_details_charts_view.dart
+++ b/lib/widgets/transaction_details_charts_view.dart
@@ -7,7 +7,6 @@ import '../providers/transactions.dart';
 import '../utils/custom_colors.dart';
 
 // Used in TransactionDetailsScreen.
-// TODO: make it so that this month's transactions are shown with other month totals.
 
 class TransactionDetailsChartsView extends StatefulWidget {
   final String transactionId;
@@ -41,29 +40,40 @@ class _TransactionDetailsChartsViewState
       children: <Widget>[
         // Need SizedBox or PageView will attempt to take up entire vertical viewport.
         SizedBox(
-          height: 290,
+          height: 285,
           child: PageView(
             controller: _pageController,
             children: <Widget>[
+              // Both pie charts will show this month's statistics if the transaction is in the current month.
+              // If not, it will show lifetime/total statistics.
+              // This pie chart is for label statistics.
               TransactionDetailsPieChart(
-                chartTitle: 'Impact on Label ${label.title}',
+                chartTitle:
+                    '${transaction.isAfterBeginningOfMonth ? 'Month\'s' : ''} Impact on Label ${label.title}',
                 transactionTitle: transaction.title,
                 otherTitle: 'Rest of ${label.title}',
                 transactionAmount: transaction.amount,
-                totalAmount: label.getLabelAmountTotal(context),
+                totalAmount: transaction.isAfterBeginningOfMonth
+                    ? label.getLabelMonthAmountTotal(context)
+                    : label.getLabelAmountTotal(context),
                 mainColor: label.color,
                 otherColor: label.color.withAlpha(125),
               ),
+              // This pie chart is for general income/expense statistics.
               TransactionDetailsPieChart(
                 chartTitle:
-                    'Impact on ${transaction.amount < 0 ? 'Expense' : 'Income'} Totals',
+                    '${transaction.isAfterBeginningOfMonth ? 'Month\'s' : ''} Impact on ${transaction.amount < 0 ? 'Expense' : 'Income'} Totals',
                 transactionTitle: transaction.title,
                 otherTitle:
                     'Rest of ${transaction.amount < 0 ? 'Expenses' : 'Income'}',
                 transactionAmount: transaction.amount,
                 totalAmount: transaction.amount > 0
-                    ? transactionsData.incomeTotal
-                    : transactionsData.expensesTotal,
+                    ? (transaction.isAfterBeginningOfMonth
+                        ? transactionsData.monthIncomeTotal
+                        : transactionsData.incomeTotal)
+                    : (transaction.isAfterBeginningOfMonth
+                        ? transactionsData.monthExpensesTotal
+                        : transactionsData.expensesTotal),
                 mainColor:
                     CustomColors.transactionTypeColor(transaction.amount),
                 otherColor: CustomColors.secondaryTransactionTypeColor(


### PR DESCRIPTION
Accidentally pushed some commits to the master branch so this PR won't show all of the changes in code.

- Add month stats for transaction detail pie charts, also add a label specific chart.
- Refactored Transactions provider
- Small performance improvements missed before.

![20-07-26-17-38-04](https://user-images.githubusercontent.com/7365763/88490113-235b7980-cf67-11ea-816d-2ec8fd10e21f.gif)
