### PR TITLE
Balance history chart

### DIFF
--- a/lib/charts/chart_models/time_series_model.dart
+++ b/lib/charts/chart_models/time_series_model.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/foundation.dart';
+
+class TimeSeriesModel {
+  final DateTime date;
+  final double value;
+
+  const TimeSeriesModel({
+    @required this.date,
+    @required this.value,
+  });
+}

--- a/lib/charts/chart_widgets/balance_history_chart.dart
+++ b/lib/charts/chart_widgets/balance_history_chart.dart
@@ -3,15 +3,16 @@ import 'package:provider/provider.dart';
 
 import '../charts_base/time_series_base.dart';
 import '../chart_models/time_series_model.dart';
+import '../../providers/insights_range.dart';
 import '../../providers/transactions.dart';
 
 class BalanceHistoryChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     // List of transactions in chronological order (oldest first).
-    // TODO: Implement range in transactions provider.
+    final range = Provider.of<InsightsRange>(context).range;
     final transactions = Provider.of<Transactions>(context, listen: false)
-        .items
+        .filterTransactionsByRange(range)
         .reversed
         .toList();
 
@@ -43,7 +44,7 @@ class BalanceHistoryChart extends StatelessWidget {
       },
     );
 
-    if (data.length < 3) {
+    if (data.length < 2) {
       return const Center(
         child: Text(
           'Add some more transactions!',

--- a/lib/charts/chart_widgets/balance_history_chart.dart
+++ b/lib/charts/chart_widgets/balance_history_chart.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../charts_base/time_series_base.dart';
+import '../chart_models/time_series_model.dart';
+import '../../providers/transactions.dart';
+
+class BalanceHistoryChart extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // List of transactions in chronological order (oldest first).
+    // TODO: Implement range in transactions provider.
+    final transactions = Provider.of<Transactions>(context, listen: false)
+        .items
+        .reversed
+        .toList();
+
+    // Each TimeSeriesModel will contain one date with the sum of the transaction amounts from that specific day.
+    final data = <TimeSeriesModel>[];
+
+    transactions.forEach(
+      (transaction) {
+        // Checks if the dates are the same. If they are, add the value to the same day.
+        // Also check to see whether they are in range or not.
+        if (data.length > 0 &&
+            data.last.date.compareTo(transaction.date) == 0) {
+          // Can't update the value directly since it is declared as final.
+          final updatedTimeSeriesModel = TimeSeriesModel(
+            date: transaction.date,
+            value: data.last.value + transaction.amount,
+          );
+          data.removeLast();
+          data.add(updatedTimeSeriesModel);
+        } else {
+          data.add(
+            TimeSeriesModel(
+              date: transaction.date,
+              value:
+                  transaction.amount + (data.isNotEmpty ? data.last.value : 0),
+            ),
+          );
+        }
+      },
+    );
+
+    if (data.length < 3) {
+      return const Center(
+        child: Text(
+          'Add some more transactions!',
+          style: TextStyle(fontSize: 15),
+        ),
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: TimeSeriesBase(
+        id: 'Balance History',
+        color: Colors.blueAccent,
+        data: data,
+      ),
+    );
+  }
+}

--- a/lib/charts/chart_widgets/transaction_details_pie_chart.dart
+++ b/lib/charts/chart_widgets/transaction_details_pie_chart.dart
@@ -32,9 +32,12 @@ class TransactionDetailsPieChart extends StatelessWidget {
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: <Widget>[
-        Text(
-          chartTitle,
-          style: Theme.of(context).textTheme.headline6.copyWith(fontSize: 22),
+        // Just in case the text overflows.
+        FittedBox(
+          child: Text(
+            chartTitle,
+            style: Theme.of(context).textTheme.headline6.copyWith(fontSize: 22),
+          ),
         ),
         SizedBox(
           height: height,

--- a/lib/charts/charts_base/time_series_base.dart
+++ b/lib/charts/charts_base/time_series_base.dart
@@ -33,6 +33,7 @@ class TimeSeriesBase extends StatelessWidget {
     return charts.TimeSeriesChart(
       chartData,
       animate: false,
+      defaultInteractions: false,
     );
   }
 }

--- a/lib/charts/charts_base/time_series_base.dart
+++ b/lib/charts/charts_base/time_series_base.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:charts_flutter/flutter.dart' as charts;
+
+import '../chart_models/time_series_model.dart';
+
+class TimeSeriesBase extends StatelessWidget {
+  final String id;
+  final charts.Color color;
+  final List<TimeSeriesModel> data;
+
+  TimeSeriesBase({
+    @required this.id,
+    @required Color color,
+    @required this.data,
+  }) : // Convert material color to chart color.
+        this.color = charts.Color(
+            r: color.red, g: color.green, b: color.blue, a: color.alpha);
+
+  List<charts.Series<TimeSeriesModel, DateTime>> get chartData {
+    return [
+      charts.Series<TimeSeriesModel, DateTime>(
+        id: id,
+        colorFn: (_, __) => color,
+        domainFn: (data, _) => data.date,
+        measureFn: (data, _) => data.value,
+        data: data,
+      ),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return charts.TimeSeriesChart(
+      chartData,
+      animate: false,
+    );
+  }
+}

--- a/lib/models/label.dart
+++ b/lib/models/label.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import './transaction.dart';
 import '../providers/insights_range.dart';
 import '../providers/transactions.dart';
 

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -36,7 +36,7 @@ class DashboardScreen extends StatelessWidget {
         child: FutureBuilder(
           future: fetchAndSetData(context),
           builder: (context, snapshot) {
-            if (snapshot.connectionState == ConnectionState.waiting) {
+            if (snapshot.connectionState != ConnectionState.done) {
               return const Center(
                 child: CircularProgressIndicator(),
               );

--- a/lib/screens/edit_transaction_screen.dart
+++ b/lib/screens/edit_transaction_screen.dart
@@ -74,8 +74,10 @@ class _EditTransactionScreenState extends State<EditTransactionScreen> {
   // Initialized later and determines what is shown in the Label FormField.
   // Mostly needed for the color of the label text field.
   Label _selectedLabel;
-  // Default date should be now.
-  var _selectedDate = DateTime.now();
+  // Default date should be now. Also remove time on the date. If the time is there, it messes up the balance history
+  // graph.
+  var _selectedDate =
+      DateTime(DateTime.now().year, DateTime.now().month, DateTime.now().day);
   // To set the text inside the date text field.
   final _dateController = TextEditingController();
 

--- a/lib/screens/insights_screen.dart
+++ b/lib/screens/insights_screen.dart
@@ -67,6 +67,7 @@ class _InsightsScreenState extends State<InsightsScreen> {
             orientation: Axis.vertical,
             dotColor: Colors.white30,
             dotSelectedColor: Colors.white,
+            dotSpacing: 16,
             controller: _pageController,
             itemCount: _graphScreens.length,
           ),

--- a/lib/screens/insights_screen.dart
+++ b/lib/screens/insights_screen.dart
@@ -4,6 +4,7 @@ import 'package:scrolling_page_indicator/scrolling_page_indicator.dart';
 
 import '../models/label.dart';
 import '../charts/chart_widgets/labels_pie_chart.dart';
+import '../charts/chart_widgets/balance_history_chart.dart';
 import '../providers/insights_range.dart';
 import '../utils/custom_colors.dart';
 import '../widgets/chart_container.dart';
@@ -35,6 +36,11 @@ class _InsightsScreenState extends State<InsightsScreen> {
       chart: LabelsPieChart(labelType: LabelType.EXPENSE),
       backgroundColor: CustomColors.expenseColor,
     ),
+    ChartContainer(
+      title: 'Balance History',
+      chart: BalanceHistoryChart(),
+      backgroundColor: Colors.blue[800],
+    )
   ];
 
   @override


### PR DESCRIPTION
- Add basic balance history chart
- It was hard to make it look good using the flutter charts library, might switch to a different one to make it fit the design language of the app better. Might use [FL Chart](https://pub.dev/packages/fl_chart)
- Prevent overflow on TransactionDetailsPieChart
- Prevent the default date on EditTransactionScreen to have time data in it, might mess up filtering a little

![20-07-30-17-04-36](https://user-images.githubusercontent.com/7365763/88974802-2fa54680-d287-11ea-8ead-063326fc38fb.gif)
